### PR TITLE
Add built-in package support

### DIFF
--- a/src/main/antlr/org/ballerinalang/plugins/idea/grammar/BallerinaParser.g4
+++ b/src/main/antlr/org/ballerinalang/plugins/idea/grammar/BallerinaParser.g4
@@ -172,6 +172,11 @@ typeName
 referenceTypeName
     :   builtInReferenceTypeName
     |   nameReference
+    |   anonStructTypeName
+    ;
+
+anonStructTypeName
+    : STRUCT LEFT_BRACE structBody RIGHT_BRACE
     ;
 
 valueTypeName

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/IdentifierPSINode.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/IdentifierPSINode.java
@@ -180,9 +180,10 @@ public class IdentifierPSINode extends ANTLRPsiLeafNode implements PsiNamedEleme
                         }
                     } else {
                         PsiElement prevSibling = parent.getPrevSibling();
-                        variableReference = prevSibling.findReferenceAt(prevSibling.getTextLength());
+                        if (prevSibling != null) {
+                            return new FieldReference(this);
+                        }
                     }
-
                     if (variableReference == null) {
                         return null;
                     }

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/IdentifierPSINode.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/IdentifierPSINode.java
@@ -302,7 +302,7 @@ public class IdentifierPSINode extends ANTLRPsiLeafNode implements PsiNamedEleme
         return null;
     }
 
-    @NotNull
+    @Nullable
     private PsiReference suggestReferenceType(@NotNull PsiElement parent) {
         PsiElement nextVisibleLeaf = PsiTreeUtil.nextVisibleLeaf(getParent());
         if (nextVisibleLeaf != null) {

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/AnnotationReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/AnnotationReference.java
@@ -112,7 +112,7 @@ public class AnnotationReference extends BallerinaElementReference {
     private PsiElement findMatchingAnnotationDefinition(@NotNull PsiDirectory currentPackage, boolean includePrivate) {
         IdentifierPSINode identifier = getElement();
         List<IdentifierPSINode> annotations = BallerinaPsiImplUtil.getAllAnnotationsInPackage(currentPackage,
-                includePrivate);
+                includePrivate, true);
         for (IdentifierPSINode annotation : annotations) {
             String text = annotation.getText();
             if (text.equals(identifier.getText())) {
@@ -142,14 +142,14 @@ public class AnnotationReference extends BallerinaElementReference {
         }
         List<IdentifierPSINode> annotations;
         if (allAnnotations) {
-            annotations = BallerinaPsiImplUtil.getAllAnnotationsInPackage(containingPackage, true);
+            annotations = BallerinaPsiImplUtil.getAllAnnotationsInPackage(containingPackage, true, false);
         } else {
             String attachmentType = BallerinaPsiImplUtil.getAttachmentType(identifier);
             if (attachmentType == null) {
                 return results;
             }
             annotations = BallerinaPsiImplUtil.getAllAnnotationAttachmentsForType(containingPackage, attachmentType,
-                    true);
+                    true, false);
         }
         results.addAll(BallerinaCompletionUtils.createAnnotationLookupElements(annotations));
         return results;
@@ -167,14 +167,14 @@ public class AnnotationReference extends BallerinaElementReference {
         PsiDirectory resolvedPackage = (PsiDirectory) resolvedElement;
         List<IdentifierPSINode> annotations;
         if (allAnnotations) {
-            annotations = BallerinaPsiImplUtil.getAllAnnotationsInPackage(resolvedPackage, false);
+            annotations = BallerinaPsiImplUtil.getAllAnnotationsInPackage(resolvedPackage, false, false);
         } else {
             String attachmentType = BallerinaPsiImplUtil.getAttachmentType(identifier);
             if (attachmentType == null) {
                 return results;
             }
             annotations = BallerinaPsiImplUtil.getAllAnnotationAttachmentsForType(resolvedPackage, attachmentType,
-                    false);
+                    false, false);
         }
         results.addAll(BallerinaCompletionUtils.createAnnotationLookupElements(annotations));
         return results;

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/ConnectorReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/ConnectorReference.java
@@ -81,7 +81,7 @@ public class ConnectorReference extends BallerinaElementReference {
             return null;
         }
         PsiElement element = BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, false, true,
-                false, false, false, false, true);
+                false, false, false, false, true, true);
         if (element != null) {
             return element;
         }
@@ -97,8 +97,7 @@ public class ConnectorReference extends BallerinaElementReference {
         }
         PsiDirectory psiDirectory = (PsiDirectory) resolvedElement;
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, false, true, false, false,
-                false,
-                false, false);
+                false, false, false, false);
     }
 
     @NotNull
@@ -112,7 +111,7 @@ public class ConnectorReference extends BallerinaElementReference {
         PsiDirectory containingPackage = originalFile.getParent();
         if (containingPackage != null) {
             List<IdentifierPSINode> connectors = BallerinaPsiImplUtil.getAllConnectorsFromPackage(containingPackage,
-                    true);
+                    true, true);
             results.addAll(BallerinaCompletionUtils.createConnectorLookupElements(connectors,
                     ParenthesisInsertHandler.INSTANCE));
         }
@@ -131,7 +130,8 @@ public class ConnectorReference extends BallerinaElementReference {
             return results;
         }
         PsiDirectory resolvedPackage = (PsiDirectory) resolvedElement;
-        List<IdentifierPSINode> connectors = BallerinaPsiImplUtil.getAllConnectorsFromPackage(resolvedPackage, false);
+        List<IdentifierPSINode> connectors = BallerinaPsiImplUtil.getAllConnectorsFromPackage(resolvedPackage, false,
+                false);
         results.addAll(BallerinaCompletionUtils.createConnectorLookupElements(connectors,
                 ParenthesisInsertHandler.INSTANCE));
         return results;

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/EnumReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/EnumReference.java
@@ -66,7 +66,7 @@ public class EnumReference extends BallerinaElementReference {
             return null;
         }
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, false, false, false, true,
-                false, false, true);
+                false, false, true, true);
     }
 
     @Nullable
@@ -78,7 +78,7 @@ public class EnumReference extends BallerinaElementReference {
         }
         PsiDirectory psiDirectory = (PsiDirectory) resolvedElement;
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, false, false, false, true,
-                false, false, false);
+                false, false, false, false);
     }
 
     @NotNull
@@ -106,8 +106,7 @@ public class EnumReference extends BallerinaElementReference {
         PsiDirectory containingPackage = originalFile.getParent();
 
         if (containingPackage != null) {
-            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(containingPackage,
-                    true);
+            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(containingPackage, true, true);
             results.addAll(BallerinaCompletionUtils.createEnumLookupElements(enums));
         }
         return results;
@@ -121,7 +120,7 @@ public class EnumReference extends BallerinaElementReference {
             return results;
         }
         PsiDirectory resolvedPackage = (PsiDirectory) resolvedElement;
-        List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(resolvedPackage, false);
+        List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(resolvedPackage, false, false);
         results.addAll(BallerinaCompletionUtils.createEnumLookupElements(enums));
         return results;
     }

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/FieldReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/FieldReference.java
@@ -25,12 +25,15 @@ import org.ballerinalang.plugins.idea.psi.CodeBlockParameterNode;
 import org.ballerinalang.plugins.idea.psi.EnumDefinitionNode;
 import org.ballerinalang.plugins.idea.psi.EnumFieldNode;
 import org.ballerinalang.plugins.idea.psi.FieldDefinitionNode;
+import org.ballerinalang.plugins.idea.psi.FunctionDefinitionNode;
 import org.ballerinalang.plugins.idea.psi.IdentifierPSINode;
 import org.ballerinalang.plugins.idea.psi.NameReferenceNode;
 import org.ballerinalang.plugins.idea.psi.ParameterNode;
 import org.ballerinalang.plugins.idea.psi.StatementNode;
 import org.ballerinalang.plugins.idea.psi.StructDefinitionNode;
+import org.ballerinalang.plugins.idea.psi.TypeNameNode;
 import org.ballerinalang.plugins.idea.psi.VariableDefinitionNode;
+import org.ballerinalang.plugins.idea.psi.VariableReferenceNode;
 import org.ballerinalang.plugins.idea.psi.impl.BallerinaPsiImplUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -150,6 +153,39 @@ public class FieldReference extends BallerinaElementReference {
         }
         PsiReference reference = previousField.findReferenceAt(0);
         if (reference == null) {
+            PsiElement prevSibling = identifier.getParent().getPrevSibling();
+            if (prevSibling == null) {
+                return new LookupElement[0];
+            }
+            if (prevSibling instanceof VariableReferenceNode) {
+                PsiElement[] children = prevSibling.getChildren();
+                if (children.length <= 0) {
+                    return new LookupElement[0];
+                }
+                PsiElement firstChild = children[0].getFirstChild();
+                if (firstChild == null) {
+                    return new LookupElement[0];
+                }
+                PsiReference functionReference = firstChild.findReferenceAt(firstChild.getTextLength());
+                if (functionReference == null) {
+                    return new LookupElement[0];
+                }
+                PsiElement resolvedElement = functionReference.resolve();
+                if (resolvedElement == null) {
+                    return new LookupElement[0];
+                }
+                PsiElement parent = resolvedElement.getParent();
+                if (parent instanceof FunctionDefinitionNode) {
+                    List<TypeNameNode> returnTypes =
+                            BallerinaPsiImplUtil.getReturnTypes(((FunctionDefinitionNode) parent));
+                    if (returnTypes.size() == 1) {
+                        TypeNameNode typeNameNode = returnTypes.get(0);
+                        reference = typeNameNode.findReferenceAt(typeNameNode.getTextLength());
+                    }
+                }
+            }
+        }
+        if (reference == null) {
             return new LookupElement[0];
         }
 
@@ -184,6 +220,8 @@ public class FieldReference extends BallerinaElementReference {
             results.addAll(BallerinaCompletionUtils.createEnumFieldLookupElements(fieldDefinitionNodes,
                     (IdentifierPSINode) resolvedElement));
             return results.toArray(new LookupElement[results.size()]);
+        }else if (resolvedElementParent instanceof StructDefinitionNode) {
+            structDefinitionNode= ((StructDefinitionNode) resolvedElementParent);
         }
         if (structDefinitionNode == null) {
             return new LookupElement[0];

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/FieldReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/FieldReference.java
@@ -80,11 +80,27 @@ public class FieldReference extends BallerinaElementReference {
                 prevSibling = PsiTreeUtil.prevVisibleLeaf(prevSibling);
             }
         } else {
-            // If the current statement is correctly resolved, that means all the fields are identified properly.
-            // Get the prevSibling. This is used to resolve the current field.
-            prevSibling = PsiTreeUtil.prevVisibleLeaf(parent);
+            PsiElement parentPrevSibling = parent.getPrevSibling();
+            if (parentPrevSibling != null) {
+                if (parentPrevSibling instanceof VariableReferenceNode) {
+                    PsiElement[] children = parentPrevSibling.getChildren();
+                    if (children.length <= 0) {
+                        return null;
+                    }
+                    PsiElement firstChild = children[0].getFirstChild();
+                    if (firstChild == null) {
+                        return null;
+                    }
+                    prevSibling = firstChild;
+                } else {
+                    return null;
+                }
+            } else {
+                // If the current statement is correctly resolved, that means all the fields are identified properly.
+                // Get the prevSibling. This is used to resolve the current field.
+                prevSibling = PsiTreeUtil.prevVisibleLeaf(parent);
+            }
         }
-
         // If the prevSibling is null, we return from this method because we cannot resolve the element.
         if (prevSibling == null) {
             return null;
@@ -220,8 +236,8 @@ public class FieldReference extends BallerinaElementReference {
             results.addAll(BallerinaCompletionUtils.createEnumFieldLookupElements(fieldDefinitionNodes,
                     (IdentifierPSINode) resolvedElement));
             return results.toArray(new LookupElement[results.size()]);
-        }else if (resolvedElementParent instanceof StructDefinitionNode) {
-            structDefinitionNode= ((StructDefinitionNode) resolvedElementParent);
+        } else if (resolvedElementParent instanceof StructDefinitionNode) {
+            structDefinitionNode = ((StructDefinitionNode) resolvedElementParent);
         }
         if (structDefinitionNode == null) {
             return new LookupElement[0];

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/FunctionReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/FunctionReference.java
@@ -91,7 +91,7 @@ public class FunctionReference extends BallerinaElementReference {
             return element;
         }
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, true, false, false, false,
-                false, false, true);
+                false, false, true, true);
     }
 
     @Nullable
@@ -103,7 +103,7 @@ public class FunctionReference extends BallerinaElementReference {
         }
         PsiDirectory psiDirectory = (PsiDirectory) resolvedElement;
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, true, false, false, false,
-                false, false, false);
+                false, false, false, false);
     }
 
     @NotNull
@@ -116,7 +116,7 @@ public class FunctionReference extends BallerinaElementReference {
 
         if (containingPackage != null) {
             List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(containingPackage,
-                    true);
+                    true, true);
             results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions,
                     ParenthesisInsertHandler.INSTANCE));
         }
@@ -167,7 +167,8 @@ public class FunctionReference extends BallerinaElementReference {
             return results;
         }
         PsiDirectory resolvedPackage = (PsiDirectory) resolvedElement;
-        List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(resolvedPackage, false);
+        List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(resolvedPackage, false,
+                false);
         results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions));
         return results;
     }

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/NameReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/NameReference.java
@@ -104,7 +104,7 @@ public class NameReference extends BallerinaElementReference {
         PsiElement nextVisibleLeaf = PsiTreeUtil.nextVisibleLeaf(identifier);
         if (nextVisibleLeaf != null && "(".equals(nextVisibleLeaf.getText())) {
             PsiElement element = BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, true, true,
-                    true, true, true, true, true);
+                    true, true, true, true, true, true);
             if (element != null) {
                 return element;
             }
@@ -118,10 +118,10 @@ public class NameReference extends BallerinaElementReference {
             TypeNameNode typeNameNode = PsiTreeUtil.getParentOfType(identifier, TypeNameNode.class);
             if (typeNameNode == null) {
                 resolvedElement = BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, true, true,
-                        true, true, true, true, true);
+                        true, true, true, true, true, true);
             } else {
                 resolvedElement = BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, false, true,
-                        true, true, false, false, true);
+                        true, true, false, false, true, true);
             }
             if (resolvedElement != null) {
                 return resolvedElement;
@@ -139,7 +139,7 @@ public class NameReference extends BallerinaElementReference {
         PsiDirectory psiDirectory = (PsiDirectory) resolvedElement;
         IdentifierPSINode identifier = getElement();
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, true, true, true, true, true,
-                true, false);
+                true, false, false);
     }
 
     @NotNull
@@ -173,7 +173,7 @@ public class NameReference extends BallerinaElementReference {
                             prevVisibleLeaf.getText().matches("[{}]"))) {
 
                 List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage
-                        (containingPackage, true);
+                        (containingPackage, true, true);
                 results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions));
 
                 // Todo - use a util method
@@ -204,14 +204,15 @@ public class NameReference extends BallerinaElementReference {
             }
 
             List<IdentifierPSINode> connectors = BallerinaPsiImplUtil.getAllConnectorsFromPackage(containingPackage,
-                    true);
+                    true, true);
             results.addAll(BallerinaCompletionUtils.createConnectorLookupElements(connectors,
                     AddSpaceInsertHandler.INSTANCE));
 
-            List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, true);
+            List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, true,
+                    true);
             results.addAll(BallerinaCompletionUtils.createStructLookupElements(structs));
 
-            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(containingPackage, true);
+            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(containingPackage, true, true);
             results.addAll(BallerinaCompletionUtils.createEnumLookupElements(enums));
             return results;
         }
@@ -246,31 +247,32 @@ public class NameReference extends BallerinaElementReference {
                 AnnotationAttachmentNode.class);
         if (attachmentNode != null) {
             List<IdentifierPSINode> constants = BallerinaPsiImplUtil.getAllConstantsFromPackage(containingPackage,
-                    false);
+                    false, false);
             results.addAll(BallerinaCompletionUtils.createConstantLookupElements(constants));
         } else {
             // Todo - use a util method
             List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(containingPackage,
-                    false);
+                    false, false);
             results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions));
 
             List<IdentifierPSINode> connectors = BallerinaPsiImplUtil.getAllConnectorsFromPackage(containingPackage,
-                    false);
+                    false, false);
             results.addAll(BallerinaCompletionUtils.createConnectorLookupElements(connectors,
                     AddSpaceInsertHandler.INSTANCE));
 
-            List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, false);
+            List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage,
+                    false, false);
             results.addAll(BallerinaCompletionUtils.createStructLookupElements(structs));
 
-            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(containingPackage, true);
+            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(containingPackage, true, false);
             results.addAll(BallerinaCompletionUtils.createEnumLookupElements(enums));
 
             List<IdentifierPSINode> globalVariables =
-                    BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(containingPackage, false);
+                    BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(containingPackage, false, false);
             results.addAll(BallerinaCompletionUtils.createGlobalVariableLookupElements(globalVariables));
 
             List<IdentifierPSINode> constants = BallerinaPsiImplUtil.getAllConstantsFromPackage(containingPackage,
-                    false);
+                    false, false);
             results.addAll(BallerinaCompletionUtils.createConstantLookupElements(constants));
         }
         return results;

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/StatementReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/StatementReference.java
@@ -67,7 +67,7 @@ public class StatementReference extends BallerinaElementReference {
             }
             PsiDirectory containingPackage = (PsiDirectory) resolvedElement;
             return BallerinaPsiImplUtil.resolveElementInPackage(containingPackage, identifier, true, true, true,
-                    true, true, true, false);
+                    true, true, true, false, false);
         } else {
             return BallerinaPsiImplUtil.resolveElementInScope(identifier, true, true, true, true);
         }
@@ -168,7 +168,7 @@ public class StatementReference extends BallerinaElementReference {
         PsiDirectory containingPackage = originalFile.getParent();
         if (containingPackage != null) {
             List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(containingPackage,
-                    true);
+                    true, true);
             results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions));
         }
         return results;
@@ -185,24 +185,28 @@ public class StatementReference extends BallerinaElementReference {
         PsiDirectory containingPackage = (PsiDirectory) resolvedElement;
 
         // Todo - add util method
-        List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(containingPackage, false);
-        functions= functions.stream()
+        List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(containingPackage,
+                false, false);
+        functions = functions.stream()
                 .filter(function -> !BallerinaPsiImplUtil.isAttachedFunction(function))
                 .collect(Collectors.toList());
         results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions));
 
-        List<IdentifierPSINode> connectors = BallerinaPsiImplUtil.getAllConnectorsFromPackage(containingPackage, false);
+        List<IdentifierPSINode> connectors = BallerinaPsiImplUtil.getAllConnectorsFromPackage(containingPackage,
+                false, false);
         results.addAll(BallerinaCompletionUtils.createConnectorLookupElements(connectors,
                 AddSpaceInsertHandler.INSTANCE));
 
-        List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, false);
+        List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, false,
+                false);
         results.addAll(BallerinaCompletionUtils.createStructLookupElements(structs));
 
         List<IdentifierPSINode> globalVariables =
-                BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(containingPackage, false);
+                BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(containingPackage, false, false);
         results.addAll(BallerinaCompletionUtils.createGlobalVariableLookupElements(globalVariables));
 
-        List<IdentifierPSINode> constants = BallerinaPsiImplUtil.getAllConstantsFromPackage(containingPackage, false);
+        List<IdentifierPSINode> constants = BallerinaPsiImplUtil.getAllConstantsFromPackage(containingPackage,
+                false, false);
         results.addAll(BallerinaCompletionUtils.createConstantLookupElements(constants));
 
         return results;

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/StructReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/StructReference.java
@@ -81,7 +81,7 @@ public class StructReference extends BallerinaElementReference {
             return null;
         }
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, false,
-                false, true, false, false, false, true);
+                false, true, false, false, false, true, true);
     }
 
     @Nullable
@@ -93,7 +93,7 @@ public class StructReference extends BallerinaElementReference {
         PsiDirectory psiDirectory = (PsiDirectory) resolvedElement;
         IdentifierPSINode identifier = getElement();
         return BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, false, false, true, false,
-                false, false, false);
+                false, false, false, false);
     }
 
     @NotNull
@@ -103,7 +103,7 @@ public class StructReference extends BallerinaElementReference {
         PsiFile containingFile = identifier.getContainingFile();
         PsiFile originalFile = containingFile.getOriginalFile();
         PsiDirectory containingPackage = originalFile.getParent();
-        List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, true);
+        List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, true, true);
         results.addAll(BallerinaCompletionUtils.createStructLookupElements(structs));
         return results;
     }
@@ -117,7 +117,8 @@ public class StructReference extends BallerinaElementReference {
         }
 
         PsiDirectory containingPackage = (PsiDirectory) resolvedElement;
-        List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, false);
+        List<IdentifierPSINode> structs = BallerinaPsiImplUtil.getAllStructsFromPackage(containingPackage, false,
+                false);
         results.addAll(BallerinaCompletionUtils.createStructLookupElements(structs));
         return results;
     }

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/StructValueReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/StructValueReference.java
@@ -63,7 +63,7 @@ public class StructValueReference extends BallerinaElementReference {
         }
         // First we try to resolve the reference to following definitions.
         PsiElement element = BallerinaPsiImplUtil.resolveElementInPackage(psiDirectory, identifier, true, true,
-                true, true, true, true, true);
+                true, true, true, true, true, true);
         if (element != null) {
             return element;
         }
@@ -107,7 +107,7 @@ public class StructValueReference extends BallerinaElementReference {
                     if (mapStructKeyNode.getText().equals(resolvedPackage.getName())) {
 
                         List<IdentifierPSINode> functions =
-                                BallerinaPsiImplUtil.getAllFunctionsFromPackage(resolvedPackage, false);
+                                BallerinaPsiImplUtil.getAllFunctionsFromPackage(resolvedPackage, false, false);
                         results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions));
 
                         Collection<EnumFieldNode> fieldDefinitionNodes =
@@ -116,11 +116,11 @@ public class StructValueReference extends BallerinaElementReference {
                                 (IdentifierPSINode) resolvedElement));
 
                         List<IdentifierPSINode> globalVariables =
-                                BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(resolvedPackage, false);
+                                BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(resolvedPackage, false, false);
                         results.addAll(BallerinaCompletionUtils.createGlobalVariableLookupElements(globalVariables));
 
                         List<IdentifierPSINode> constants =
-                                BallerinaPsiImplUtil.getAllConstantsFromPackage(resolvedPackage, false);
+                                BallerinaPsiImplUtil.getAllConstantsFromPackage(resolvedPackage, false, false);
                         results.addAll(BallerinaCompletionUtils.createConstantLookupElements(constants));
                     }
                 }
@@ -129,17 +129,19 @@ public class StructValueReference extends BallerinaElementReference {
 
         PsiDirectory currentPackage = originalFile.getParent();
         if (currentPackage != null) {
-            List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(currentPackage, true);
+            List<IdentifierPSINode> functions = BallerinaPsiImplUtil.getAllFunctionsFromPackage(currentPackage,
+                    true, true);
             results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functions));
 
-            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(currentPackage, true);
+            List<IdentifierPSINode> enums = BallerinaPsiImplUtil.getAllEnumsFromPackage(currentPackage, true, true);
             results.addAll(BallerinaCompletionUtils.createEnumLookupElements(enums));
 
             List<IdentifierPSINode> globalVariables =
-                    BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(currentPackage, true);
+                    BallerinaPsiImplUtil.getAllGlobalVariablesFromPackage(currentPackage, true, true);
             results.addAll(BallerinaCompletionUtils.createGlobalVariableLookupElements(globalVariables));
 
-            List<IdentifierPSINode> constants = BallerinaPsiImplUtil.getAllConstantsFromPackage(currentPackage, true);
+            List<IdentifierPSINode> constants = BallerinaPsiImplUtil.getAllConstantsFromPackage(currentPackage,
+                    true, true);
             results.addAll(BallerinaCompletionUtils.createConstantLookupElements(constants));
         }
 

--- a/src/main/java/org/ballerinalang/plugins/idea/psi/references/TypeReference.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/psi/references/TypeReference.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.ballerinalang.plugins.idea.psi.references;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.ballerinalang.plugins.idea.completion.BallerinaCompletionUtils;
+import org.ballerinalang.plugins.idea.psi.FunctionDefinitionNode;
+import org.ballerinalang.plugins.idea.psi.IdentifierPSINode;
+import org.ballerinalang.plugins.idea.psi.impl.BallerinaPsiImplUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class TypeReference extends BallerinaElementReference {
+
+    private PsiElement typeNameNode;
+
+    public TypeReference(@NotNull IdentifierPSINode element, PsiElement typeNameNode) {
+        super(element);
+        this.typeNameNode = typeNameNode;
+    }
+
+    @Nullable
+    @Override
+    public PsiElement resolve() {
+        IdentifierPSINode identifier = getElement();
+        String valueTypeName = typeNameNode.getText();
+        Project project = typeNameNode.getProject();
+        PsiFile psiFile = BallerinaPsiImplUtil.findPsiFileInSDK(project, typeNameNode,
+                "/ballerina/builtin/" + valueTypeName + "lib.bal");
+        if (psiFile == null) {
+            return null;
+        }
+        List<IdentifierPSINode> functionDefinitions =
+                BallerinaPsiImplUtil.getMatchingElementsFromAFile(psiFile, FunctionDefinitionNode.class, false);
+        for (IdentifierPSINode functionDefinition : functionDefinitions) {
+            if (functionDefinition != null && identifier.getText().equals(functionDefinition.getText())) {
+                return functionDefinition;
+            }
+        }
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public Object[] getVariants() {
+        String valueTypeName = typeNameNode.getText();
+        Project project = typeNameNode.getProject();
+        PsiFile psiFile = BallerinaPsiImplUtil.findPsiFileInSDK(project, typeNameNode,
+                "/ballerina/builtin/" + valueTypeName + "lib.bal");
+        if (psiFile == null) {
+            return new LookupElement[0];
+        }
+        List<LookupElement> results = new LinkedList<>();
+        List<IdentifierPSINode> functionDefinitions =
+                BallerinaPsiImplUtil.getMatchingElementsFromAFile(psiFile, FunctionDefinitionNode.class, false);
+        results.addAll(BallerinaCompletionUtils.createFunctionLookupElements(functionDefinitions));
+        return results.toArray(new LookupElement[results.size()]);
+    }
+}


### PR DESCRIPTION
This PR adds built-in package support to the IDEA plugin. This will add the capability of providing function, etc suggestions from built-in package and function suggestion for value, reference types (Eg - `someString.<caret>` will show functions in stringlib.bal, etc).

Resolves #667 
Resolves #673 
Resolves #674 