### PR TITLE
Add parameter passing support for services

### DIFF
--- a/src/main/java/org/ballerinalang/plugins/idea/runconfig/BallerinaRunningState.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/runconfig/BallerinaRunningState.java
@@ -52,18 +52,8 @@ public abstract class BallerinaRunningState<T extends BallerinaRunConfigurationB
     @Override
     protected ProcessHandler startProcess() throws ExecutionException {
         BallerinaExecutor executor = patchExecutor(createCommonExecutor());
-        // We only need to set
-        GeneralCommandLine commandLine;
-        if (myConfiguration instanceof BallerinaRunConfigurationWithMain) {
-            RunConfigurationKind runKind = ((BallerinaRunConfigurationWithMain) myConfiguration).getRunKind();
-            if (runKind == RunConfigurationKind.MAIN) {
-                commandLine = executor.withParameterString(myConfiguration.getParams()).createCommandLine();
-            } else {
-                commandLine = executor.createCommandLine();
-            }
-        } else {
-            commandLine = executor.withParameterString(myConfiguration.getParams()).createCommandLine();
-        }
+        // We only need to set parameters.
+        GeneralCommandLine commandLine = executor.withParameterString(myConfiguration.getParams()).createCommandLine();
         KillableColoredProcessHandler handler = new KillableColoredProcessHandler(commandLine, true);
         ProcessTerminatedListener.attach(handler);
         return handler;

--- a/src/main/java/org/ballerinalang/plugins/idea/runconfig/ui/BallerinaApplicationSettingsEditor.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/runconfig/ui/BallerinaApplicationSettingsEditor.java
@@ -82,11 +82,6 @@ public class BallerinaApplicationSettingsEditor extends SettingsEditor<Ballerina
         configuration.setModule(myModulesComboBox.getComponent().getSelectedModule());
         configuration.setParams(myParamsField.getComponent().getText());
         configuration.setWorkingDirectory(myWorkingDirectoryField.getComponent().getText());
-        if (runKind == RunConfigurationKind.SERVICE) {
-            myParamsField.setVisible(false);
-        } else {
-            myParamsField.setVisible(true);
-        }
     }
 
     @NotNull
@@ -135,15 +130,5 @@ public class BallerinaApplicationSettingsEditor extends SettingsEditor<Ballerina
         for (RunConfigurationKind kind : RunConfigurationKind.values()) {
             myRunKindComboBox.getComponent().addItem(kind);
         }
-        myRunKindComboBox.getComponent().addActionListener(e -> onRunKindChanged());
-    }
-
-    private void onRunKindChanged() {
-        RunConfigurationKind selectedKind = (RunConfigurationKind) myRunKindComboBox.getComponent().getSelectedItem();
-        if (selectedKind == null) {
-            selectedKind = RunConfigurationKind.MAIN;
-        }
-        boolean isMainSelected = selectedKind == RunConfigurationKind.MAIN;
-        myParamsField.setVisible(isMainSelected);
     }
 }


### PR DESCRIPTION
This PR adds parameter passing support in run configurations. So you can pass flags like 
`-B[tracelog.http].level=TRACE` to services when they are starting.

Resolves #763