### PR TITLE
Add support to provide arguments to Ballerina runtime

### DIFF
--- a/src/main/java/org/ballerinalang/plugins/idea/runconfig/ui/BallerinaApplicationSettingsEditor.form
+++ b/src/main/java/org/ballerinalang/plugins/idea/runconfig/ui/BallerinaApplicationSettingsEditor.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.ballerinalang.plugins.idea.runconfig.ui.BallerinaApplicationSettingsEditor">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -21,7 +21,7 @@
       </component>
       <vspacer id="93bd6">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="33108" class="com.intellij.openapi.ui.LabeledComponent" binding="myRunKindComboBox" custom-create="true">
@@ -53,7 +53,7 @@
       </component>
       <component id="a9397" class="com.intellij.openapi.ui.LabeledComponent" binding="myModulesComboBox" custom-create="true">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <labelLocation value="West"/>
@@ -67,6 +67,15 @@
         <properties>
           <labelLocation value="West"/>
           <text value="File"/>
+        </properties>
+      </component>
+      <component id="bc66f" class="com.intellij.openapi.ui.LabeledComponent" binding="myBallerinaParamsField" custom-create="true">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelLocation value="West"/>
+          <text value="Ballerina Tool Arguments"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/org/ballerinalang/plugins/idea/runconfig/ui/BallerinaApplicationSettingsEditor.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/runconfig/ui/BallerinaApplicationSettingsEditor.java
@@ -46,6 +46,7 @@ public class BallerinaApplicationSettingsEditor extends SettingsEditor<Ballerina
     private LabeledComponent<TextFieldWithBrowseButton> myFileField;
     private LabeledComponent<EditorTextField> myPackageField;
     private LabeledComponent<RawCommandLineEditor> myParamsField;
+    private LabeledComponent<RawCommandLineEditor> myBallerinaParamsField;
     private LabeledComponent<TextFieldWithBrowseButton> myWorkingDirectoryField;
     private LabeledComponent<ModulesComboBox> myModulesComboBox;
     private Project myProject;
@@ -69,6 +70,8 @@ public class BallerinaApplicationSettingsEditor extends SettingsEditor<Ballerina
         myModulesComboBox.getComponent().setSelectedModule(configuration.getConfigurationModule().getModule());
 
         myParamsField.getComponent().setText(configuration.getParams());
+        myBallerinaParamsField.getComponent().setText(configuration.getBallerinaToolParams());
+
         myWorkingDirectoryField.getComponent().setText(configuration.getWorkingDirectory());
     }
 
@@ -81,6 +84,7 @@ public class BallerinaApplicationSettingsEditor extends SettingsEditor<Ballerina
         configuration.setFilePath(myFileField.getComponent().getText());
         configuration.setModule(myModulesComboBox.getComponent().getSelectedModule());
         configuration.setParams(myParamsField.getComponent().getText());
+        configuration.setBallerinaParams(myBallerinaParamsField.getComponent().getText());
         configuration.setWorkingDirectory(myWorkingDirectoryField.getComponent().getText());
         if (runKind == RunConfigurationKind.SERVICE) {
             myParamsField.setVisible(false);
@@ -111,6 +115,9 @@ public class BallerinaApplicationSettingsEditor extends SettingsEditor<Ballerina
 
         myParamsField = new LabeledComponent<>();
         myParamsField.setComponent(new RawCommandLineEditor());
+
+        myBallerinaParamsField = new LabeledComponent<>();
+        myBallerinaParamsField.setComponent(new RawCommandLineEditor());
 
         myModulesComboBox = new LabeledComponent<>();
         myModulesComboBox.setComponent(new ModulesComboBox());


### PR DESCRIPTION
This PR adds the support to provide arguments to Ballerina runtime.

Eg - `--java.debug 5005` now can be added in run config to enable Java level debugging.

Resolves #415 