### PR TITLE
Update package inspection message

### DIFF
--- a/src/main/java/org/ballerinalang/plugins/idea/codeInspection/AdjustPackageNameFix.java
+++ b/src/main/java/org/ballerinalang/plugins/idea/codeInspection/AdjustPackageNameFix.java
@@ -17,11 +17,8 @@
 package org.ballerinalang.plugins.idea.codeInspection;
 
 import com.intellij.codeInsight.FileModificationService;
-import com.intellij.codeInsight.daemon.QuickFixBundle;
 import com.intellij.codeInspection.LocalQuickFixAndIntentionActionOnPsiElement;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
@@ -30,7 +27,6 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.IncorrectOperationException;
 import org.ballerinalang.plugins.idea.psi.PackageDeclarationNode;
 import org.ballerinalang.plugins.idea.psi.impl.BallerinaElementFactory;
-import org.ballerinalang.plugins.idea.sdk.BallerinaSdkService;
 import org.ballerinalang.plugins.idea.util.BallerinaUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -47,12 +43,15 @@ public class AdjustPackageNameFix extends LocalQuickFixAndIntentionActionOnPsiEl
     @Override
     @NotNull
     public String getFamilyName() {
-        return "Adjust Package Name";
+        return "Adjust package name";
     }
 
     @NotNull
     @Override
     public String getText() {
+        if (myName.isEmpty()) {
+            return "Remove package declaration";
+        }
         return "Set package name to '" + myName + "'";
     }
 


### PR DESCRIPTION
This PR updates the package inspections display message when the package name is empty to "Remove package declaration".

Resolves #769